### PR TITLE
Add `--record-fix`, fixes Proguard stripping record data

### DIFF
--- a/src/main/java/net/minecraftforge/fart/IdentifierFixer.java
+++ b/src/main/java/net/minecraftforge/fart/IdentifierFixer.java
@@ -30,7 +30,7 @@ import org.objectweb.asm.MethodVisitor;
 
 import net.minecraftforge.fart.api.Transformer;
 
-class IdentifierFixer implements Transformer {
+class IdentifierFixer extends OptionalChangeTransformer {
     enum Config {
         // Checks all Local variables if they are valid java identifiers.
         ALL,
@@ -38,30 +38,16 @@ class IdentifierFixer implements Transformer {
         SNOWMEN;
     }
 
-    private final Config config;
-
     IdentifierFixer(Config config) {
-        this.config = config;
+        super(parent -> new Fixer(config, parent));
     }
 
-    @Override
-    public ClassEntry process(ClassEntry entry) {
-        ClassReader reader = new ClassReader(entry.getData());
-        ClassWriter writer = new ClassWriter(reader, 0);
-        Fixer fixer = new Fixer(writer);
+    private static class Fixer extends ClassFixer {
+        private final Config config;
 
-        reader.accept(fixer, 0);
-
-        if (!fixer.madeChange())
-            return entry;
-
-        return ClassEntry.create(entry.getName(), entry.getTime(), writer.toByteArray());
-    }
-
-    private class Fixer extends ClassVisitor {
-        private boolean madeChange = false;
-        public Fixer(ClassVisitor parent) {
-            super(Main.MAX_ASM_VERSION, parent);
+        public Fixer(Config config, ClassVisitor parent) {
+            super(parent);
+            this.config = config;
         }
 
         public boolean madeChange() {

--- a/src/main/java/net/minecraftforge/fart/Main.java
+++ b/src/main/java/net/minecraftforge/fart/Main.java
@@ -51,6 +51,7 @@ public class Main {
         OptionSpec<File> logO    = parser.accepts("log",    "File to log data to, optional, defaults to System.out").withRequiredArg().ofType(File.class);
         OptionSpec<File> libO    = parser.acceptsAll(Arrays.asList("lib", "e"), "Additional library to use for inheritence").withRequiredArg().ofType(File.class);
         OptionSpec<Void> fixAnnO = parser.accepts("ann-fix", "Fixes misaligned parameter annotations caused by Proguard.");
+        OptionSpec<Void> fixRecordsO = parser.accepts("record-fix", "Fixes record component data stripped by Proguard.");
         OptionSpec<IdentifierFixer.Config> fixIdsO = parser.accepts("ids-fix", "Fixes local variables that are not valid java identifiers.").withOptionalArg().withValuesConvertedBy(new IDConverter()).defaultsTo(IdentifierFixer.Config.ALL);
         OptionSpec<SourceFixer.Config> fixSrcO = parser.accepts("src-fix", "Fixes the 'SourceFile' attribute of classes.").withOptionalArg().withValuesConvertedBy(new SrcConverter()).defaultsTo(SourceFixer.Config.JAVA);
         OptionSpec<Integer> threadsO = parser.accepts("threads", "Number of threads to use, defaults to processor count.").withRequiredArg().ofType(Integer.class).defaultsTo(Runtime.getRuntime().availableProcessors());
@@ -108,6 +109,13 @@ public class Main {
             builder.add(new ParameterAnnotationFixer());
         } else {
             log("Fix Annotations: false");
+        }
+
+        if (options.has(fixRecordsO)) {
+            log("Fix Records: true");
+            builder.add(new RecordFixer());
+        } else {
+            log("Fix Records: false");
         }
 
         if (options.has(fixIdsO)) {

--- a/src/main/java/net/minecraftforge/fart/OptionalChangeTransformer.java
+++ b/src/main/java/net/minecraftforge/fart/OptionalChangeTransformer.java
@@ -1,3 +1,22 @@
+/*
+ * Forge Auto Renaming Tool
+ * Copyright (c) 2021
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.fart;
 
 import net.minecraftforge.fart.api.Transformer;

--- a/src/main/java/net/minecraftforge/fart/OptionalChangeTransformer.java
+++ b/src/main/java/net/minecraftforge/fart/OptionalChangeTransformer.java
@@ -1,0 +1,46 @@
+package net.minecraftforge.fart;
+
+import net.minecraftforge.fart.api.Transformer;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+
+import java.util.function.Function;
+
+abstract class OptionalChangeTransformer implements Transformer {
+    protected final Function<ClassVisitor, ClassFixer> fixerFactory;
+
+    protected OptionalChangeTransformer(Function<ClassVisitor, ClassFixer> fixerFactory) {
+        this.fixerFactory = fixerFactory;
+    }
+
+    @Override
+    public ClassEntry process(ClassEntry entry) {
+        ClassReader reader = new ClassReader(entry.getData());
+        ClassWriter writer = new ClassWriter(reader, 0);
+        ClassFixer fixer = fixerFactory.apply(writer);
+
+        reader.accept(fixer, 0);
+
+        if (!fixer.madeChange())
+            return entry;
+
+        return ClassEntry.create(entry.getName(), entry.getTime(), writer.toByteArray());
+    }
+
+    protected abstract static class ClassFixer extends ClassVisitor {
+        protected boolean madeChange = false;
+
+        protected ClassFixer(ClassVisitor parent) {
+            this(Main.MAX_ASM_VERSION, parent);
+        }
+
+        protected ClassFixer(int api, ClassVisitor classVisitor) {
+            super(api, classVisitor);
+        }
+
+        public boolean madeChange() {
+            return this.madeChange;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/fart/RecordFixer.java
+++ b/src/main/java/net/minecraftforge/fart/RecordFixer.java
@@ -1,0 +1,89 @@
+/*
+ * Forge Auto Renaming Tool
+ * Copyright (c) 2021
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fart;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.RecordComponentVisitor;
+import org.objectweb.asm.tree.ClassNode;
+
+class RecordFixer extends OptionalChangeTransformer {
+    protected RecordFixer() {
+        super(Fixer::new);
+    }
+
+    @Override
+    public ClassEntry process(ClassEntry entry) {
+        ClassReader reader = new ClassReader(entry.getData());
+        ClassWriter writer = new ClassWriter(reader, 0);
+        ClassNode node = new ClassNode();
+        ClassFixer fixer = fixerFactory.apply(node);
+
+        reader.accept(fixer, 0);
+
+        if (!fixer.madeChange())
+            return entry;
+
+        node.accept(writer);
+
+        return ClassEntry.create(entry.getName(), entry.getTime(), writer.toByteArray());
+    }
+
+    private static class Fixer extends ClassFixer {
+        private boolean isRecord;
+        private boolean hasRecordComponents;
+        private boolean addingRecordComponents;
+
+        public Fixer(ClassVisitor parent) {
+            super(parent);
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            this.isRecord = "java/lang/Record".equals(superName);
+            if (isRecord && (access & Opcodes.ACC_RECORD) == 0) {
+                // Add back the record flag if this class extends from Record but is missing it because of Proguard stripping
+                access |= Opcodes.ACC_RECORD;
+                this.madeChange = true;
+            }
+            super.visit(version, access, name, signature, superName, interfaces);
+        }
+
+        @Override
+        public RecordComponentVisitor visitRecordComponent(String name, String descriptor, String signature) {
+            this.hasRecordComponents = true;
+            return super.visitRecordComponent(name, descriptor, signature);
+        }
+
+        @Override
+        public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+            if (isRecord && (addingRecordComponents || !hasRecordComponents) && (access & Opcodes.ACC_PRIVATE) != 0 && (access & Opcodes.ACC_FINAL) != 0 && (access & Opcodes.ACC_STATIC) == 0) {
+                this.madeChange = true;
+                this.addingRecordComponents = true;
+                // Manually add the record component back if this class doesn't have any
+                this.visitRecordComponent(name, descriptor, signature);
+            }
+            return super.visitField(access, name, descriptor, signature, value);
+        }
+    }
+}


### PR DESCRIPTION
The `--record-fix` option fixes record metadata that is lost from Proguard stripping. It seems that Proguard is currently stripping the `ACC_RECORD` flag from the class access flag and stripping the record component data.

* `ACC_RECORD` is added back to the class access flag if the super classname is `java/lang/Record`
* Record components are recreated if they are missing based on field data if the field is `private final` and NOT `static`
* A new `OptionalChangeTransformer` abstract class is used to share some code between `RecordFixer`, `IdentifierFixer`, and `SourceFixer`