### PR TITLE
Expose transformers to API and allow redirecting logging

### DIFF
--- a/src/main/java/net/minecraftforge/fart/Main.java
+++ b/src/main/java/net/minecraftforge/fart/Main.java
@@ -21,7 +21,6 @@ package net.minecraftforge.fart;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
@@ -58,94 +57,96 @@ public class Main {
         OptionSpec<File> ffLinesO = parser.accepts("ff-line-numbers", "Applies line number corrections from Fernflower.").withRequiredArg().ofType(File.class);
         OptionSet options = parser.parse(expandArgs(args));
 
+        Consumer<String> log = ln -> {
+            if (!ln.isEmpty()) {
+                System.out.println(ln);
+            }
+        };
         if (options.has(logO)) {
             PrintStream out = System.out;
-            PrintStream log = new PrintStream(new FileOutputStream(options.valueOf(logO)));
-            hookStdOut(ln -> {
-                out.println(ln);
-                log.println(ln);
-            });
-        } else {
-            hookStdOut(System.out::println);
+            PrintStream file = new PrintStream(new FileOutputStream(options.valueOf(logO)));
+            log = ln -> {
+                if (!ln.isEmpty()) {
+                    out.println(ln);
+                    file.println(ln);
+                }
+            };
         }
 
-        log("Forge Auto Renaming Tool v" + getVersion());
+        log.accept("Forge Auto Renaming Tool v" + getVersion());
         Renamer.Builder builder = Renamer.builder();
+        builder.logger(log);
 
         // Move this up top so that the log lines are above the rest of the config as they can be spammy.
         // Its useful information but we care more about the specific configs.
         if (options.has(libO)) {
             for (File lib : options.valuesOf(libO)) {
-                log("lib: " + lib.getAbsolutePath());
+                log.accept("lib: " + lib.getAbsolutePath());
                 builder.lib(lib);
             }
         }
 
-        log("log: " + (options.has(logO) ? options.valueOf(logO).getAbsolutePath() : "null"));
+        log.accept("log: " + (options.has(logO) ? options.valueOf(logO).getAbsolutePath() : "null"));
 
         File inputF = options.valueOf(inputO);
-        log("input: " + inputF.getAbsolutePath());
+        log.accept("input: " + inputF.getAbsolutePath());
         builder.input(inputF);
 
         File outputF = options.has(outputO) ? options.valueOf(outputO) : inputF;
-        log("output: " + outputF.getAbsolutePath());
+        log.accept("output: " + outputF.getAbsolutePath());
         builder.output(outputF);
 
-        log("threads: " + options.valueOf(threadsO));
+        log.accept("threads: " + options.valueOf(threadsO));
         builder.threads(options.valueOf(threadsO));
 
         // Map is optional so that we can run other fixes without renaming.
         // This does mean that it's not strictly a 'renaming' tool but screw it I like the name.
         if (options.has(mapO)) {
             File mapF = options.valueOf(mapO);
-            log("Names: " + mapF.getAbsolutePath());
+            log.accept("Names: " + mapF.getAbsolutePath());
             builder.map(mapF);
         } else {
-            log("Names: null");
+            log.accept("Names: null");
         }
 
         if (options.has(fixAnnO)) {
-            log("Fix Annotations: true");
-            builder.add(Transformer.createParameterAnnotationFixer());
+            log.accept("Fix Annotations: true");
+            builder.add(Transformer.parameterAnnotationFixerFactory());
         } else {
-            log("Fix Annotations: false");
+            log.accept("Fix Annotations: false");
         }
 
         if (options.has(fixRecordsO)) {
-            log("Fix Records: true");
-            builder.add(Transformer.createRecordFixer());
+            log.accept("Fix Records: true");
+            builder.add(Transformer.recordFixerFactory());
         } else {
-            log("Fix Records: false");
+            log.accept("Fix Records: false");
         }
 
         if (options.has(fixIdsO)) {
-            log("Fix Identifiers: " + options.valueOf(fixIdsO));
+            log.accept("Fix Identifiers: " + options.valueOf(fixIdsO));
             builder.add(Transformer.createIdentifierFixer(options.valueOf(fixIdsO)));
         } else {
-            log("Fix Identifiers: false");
+            log.accept("Fix Identifiers: false");
         }
 
         if (options.has(fixSrcO)) {
-            log("Fix SourceFile: " + options.valueOf(fixSrcO));
-            builder.add(Transformer.createSourceFixer(options.valueOf(fixSrcO)));
+            log.accept("Fix SourceFile: " + options.valueOf(fixSrcO));
+            builder.add(Transformer.sourceFixerFactory(options.valueOf(fixSrcO)));
         } else {
-            log("Fix SourceFile: false");
+            log.accept("Fix SourceFile: false");
         }
 
         if (options.has(ffLinesO)) {
             File lines = options.valueOf(ffLinesO);
-            log("Fix Line Numbers: " + lines.getAbsolutePath());
-            builder.add(Transformer.createFernFlowerLineFixer(lines));
+            log.accept("Fix Line Numbers: " + lines.getAbsolutePath());
+            builder.add(Transformer.fernFlowerLineFixerFactory(lines));
         } else {
-            log("Fix Line Numbers: false");
+            log.accept("Fix Line Numbers: false");
         }
 
         Renamer renamer = builder.build();
         renamer.run();
-    }
-
-    private static void log(String line) {
-        System.out.println(line);
     }
 
     private static String[] expandArgs(String[] args) throws IOException {
@@ -169,80 +170,6 @@ public class Main {
     private static String getVersion() {
         final String ver = Main.class.getPackage().getImplementationVersion();
         return ver == null ? "UNKNOWN" : ver;
-    }
-
-    static void hookStdOut(final Consumer<String> consumer) {
-        final OutputStream monitorStream = new OutputStream() {
-            private byte[] buf = new byte[128];
-            private int index = 0;
-
-            private void ensure(int len) {
-                if (buf.length <= len) {
-                    byte[] old = buf;
-                    int max = buf.length << 1;
-                    while (max > 0 && max < len) {
-                        max += 1024;
-                    }
-                    if (max < 0)
-                        throw new OutOfMemoryError();
-                    buf = Arrays.copyOf(old, max);
-                }
-            }
-
-            private void send() {
-                if (index == 0)
-                    return; // TODO: Detect and support multiple empty lines?
-                String line = new String(buf, 0, index);
-                buf = new byte[128];
-                index = 0;
-                consumer.accept(line);
-            }
-
-            @Override
-            public synchronized void write(int b) {
-                if (b == '\r' || b == '\n') {
-                    send();
-                } else {
-                    ensure(index + 1);
-                    buf[index++] = (byte)b;
-                }
-            }
-
-            @Override
-            public synchronized void write(byte b[], int off, int len) {
-                if (off < 0 || len < 0 || off > b.length || (off + len) >= b.length)
-                    throw new IndexOutOfBoundsException();
-
-                while (len > 0) {
-                    int x = 0;
-                    for (; x < len; x++) {
-                        byte i = b[off + x];
-                        if (i == '\r' || i == '\n')
-                            break;
-                    }
-                    ensure(index + x);
-                    System.arraycopy(b, off, buf, index, x);
-                    index += x;
-
-                    if (x != len) {
-                        send();
-                        x++; //Skip this char
-                        len -= x;
-                        off += x;
-                        if (b[off - 1] == '\r' && b[off] == '\n') {
-                            len--;
-                            off++;
-                        }
-                    } else {
-                        off += len;
-                        len = 0;
-                    }
-                }
-            }
-        };
-
-        System.setOut(new PrintStream(monitorStream));
-        System.setErr(new PrintStream(monitorStream));
     }
 
     private static class IDConverter implements ValueConverter<IdentifierFixerConfig> {

--- a/src/main/java/net/minecraftforge/fart/Main.java
+++ b/src/main/java/net/minecraftforge/fart/Main.java
@@ -33,16 +33,16 @@ import java.util.Locale;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.objectweb.asm.Opcodes;
-
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import joptsimple.ValueConverter;
+import net.minecraftforge.fart.api.IdentifierFixerConfig;
 import net.minecraftforge.fart.api.Renamer;
+import net.minecraftforge.fart.api.SourceFixerConfig;
+import net.minecraftforge.fart.api.Transformer;
 
 public class Main {
-    static final int MAX_ASM_VERSION = Opcodes.ASM9;
     public static void main(String[] args) throws IOException {
         OptionParser parser = new OptionParser();
         OptionSpec<File> inputO  = parser.accepts("input",  "Input jar file").withRequiredArg().ofType(File.class).required();
@@ -52,8 +52,8 @@ public class Main {
         OptionSpec<File> libO    = parser.acceptsAll(Arrays.asList("lib", "e"), "Additional library to use for inheritence").withRequiredArg().ofType(File.class);
         OptionSpec<Void> fixAnnO = parser.accepts("ann-fix", "Fixes misaligned parameter annotations caused by Proguard.");
         OptionSpec<Void> fixRecordsO = parser.accepts("record-fix", "Fixes record component data stripped by Proguard.");
-        OptionSpec<IdentifierFixer.Config> fixIdsO = parser.accepts("ids-fix", "Fixes local variables that are not valid java identifiers.").withOptionalArg().withValuesConvertedBy(new IDConverter()).defaultsTo(IdentifierFixer.Config.ALL);
-        OptionSpec<SourceFixer.Config> fixSrcO = parser.accepts("src-fix", "Fixes the 'SourceFile' attribute of classes.").withOptionalArg().withValuesConvertedBy(new SrcConverter()).defaultsTo(SourceFixer.Config.JAVA);
+        OptionSpec<IdentifierFixerConfig> fixIdsO = parser.accepts("ids-fix", "Fixes local variables that are not valid java identifiers.").withOptionalArg().withValuesConvertedBy(new IDConverter()).defaultsTo(IdentifierFixerConfig.ALL);
+        OptionSpec<SourceFixerConfig> fixSrcO = parser.accepts("src-fix", "Fixes the 'SourceFile' attribute of classes.").withOptionalArg().withValuesConvertedBy(new SrcConverter()).defaultsTo(SourceFixerConfig.JAVA);
         OptionSpec<Integer> threadsO = parser.accepts("threads", "Number of threads to use, defaults to processor count.").withRequiredArg().ofType(Integer.class).defaultsTo(Runtime.getRuntime().availableProcessors());
         OptionSpec<File> ffLinesO = parser.accepts("ff-line-numbers", "Applies line number corrections from Fernflower.").withRequiredArg().ofType(File.class);
         OptionSet options = parser.parse(expandArgs(args));
@@ -106,28 +106,28 @@ public class Main {
 
         if (options.has(fixAnnO)) {
             log("Fix Annotations: true");
-            builder.add(new ParameterAnnotationFixer());
+            builder.add(Transformer.createParameterAnnotationFixer());
         } else {
             log("Fix Annotations: false");
         }
 
         if (options.has(fixRecordsO)) {
             log("Fix Records: true");
-            builder.add(new RecordFixer());
+            builder.add(Transformer.createRecordFixer());
         } else {
             log("Fix Records: false");
         }
 
         if (options.has(fixIdsO)) {
             log("Fix Identifiers: " + options.valueOf(fixIdsO));
-            builder.add(new IdentifierFixer(options.valueOf(fixIdsO)));
+            builder.add(Transformer.createIdentifierFixer(options.valueOf(fixIdsO)));
         } else {
             log("Fix Identifiers: false");
         }
 
         if (options.has(fixSrcO)) {
             log("Fix SourceFile: " + options.valueOf(fixSrcO));
-            builder.add(new SourceFixer(options.valueOf(fixSrcO)));
+            builder.add(Transformer.createSourceFixer(options.valueOf(fixSrcO)));
         } else {
             log("Fix SourceFile: false");
         }
@@ -135,7 +135,7 @@ public class Main {
         if (options.has(ffLinesO)) {
             File lines = options.valueOf(ffLinesO);
             log("Fix Line Numbers: " + lines.getAbsolutePath());
-            builder.add(new FFLineFixer(lines));
+            builder.add(Transformer.createFernFlowerLineFixer(lines));
         } else {
             log("Fix Line Numbers: false");
         }
@@ -245,37 +245,37 @@ public class Main {
         System.setErr(new PrintStream(monitorStream));
     }
 
-    private static class IDConverter implements ValueConverter<IdentifierFixer.Config> {
+    private static class IDConverter implements ValueConverter<IdentifierFixerConfig> {
         @Override
-        public IdentifierFixer.Config convert(String value) {
-            return IdentifierFixer.Config.valueOf(value.toUpperCase(Locale.ENGLISH));
+        public IdentifierFixerConfig convert(String value) {
+            return IdentifierFixerConfig.valueOf(value.toUpperCase(Locale.ENGLISH));
         }
 
         @Override
-        public Class<? extends IdentifierFixer.Config> valueType() {
-            return IdentifierFixer.Config.class;
+        public Class<? extends IdentifierFixerConfig> valueType() {
+            return IdentifierFixerConfig.class;
         }
 
         @Override
         public String valuePattern() {
-            return Arrays.stream(IdentifierFixer.Config.values()).map(Enum::name).collect(Collectors.joining("|"));
+            return Arrays.stream(IdentifierFixerConfig.values()).map(Enum::name).collect(Collectors.joining("|"));
         }
     }
 
-    private static class SrcConverter implements ValueConverter<SourceFixer.Config> {
+    private static class SrcConverter implements ValueConverter<SourceFixerConfig> {
         @Override
-        public SourceFixer.Config convert(String value) {
-            return SourceFixer.Config.valueOf(value.toUpperCase(Locale.ENGLISH));
+        public SourceFixerConfig convert(String value) {
+            return SourceFixerConfig.valueOf(value.toUpperCase(Locale.ENGLISH));
         }
 
         @Override
-        public Class<? extends SourceFixer.Config> valueType() {
-            return SourceFixer.Config.class;
+        public Class<? extends SourceFixerConfig> valueType() {
+            return SourceFixerConfig.class;
         }
 
         @Override
         public String valuePattern() {
-            return Arrays.stream(SourceFixer.Config.values()).map(Enum::name).collect(Collectors.joining("|"));
+            return Arrays.stream(SourceFixerConfig.values()).map(Enum::name).collect(Collectors.joining("|"));
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fart/Main.java
+++ b/src/main/java/net/minecraftforge/fart/Main.java
@@ -125,7 +125,7 @@ public class Main {
 
         if (options.has(fixIdsO)) {
             log.accept("Fix Identifiers: " + options.valueOf(fixIdsO));
-            builder.add(Transformer.createIdentifierFixer(options.valueOf(fixIdsO)));
+            builder.add(Transformer.identifierFixerFactory(options.valueOf(fixIdsO)));
         } else {
             log.accept("Fix Identifiers: false");
         }

--- a/src/main/java/net/minecraftforge/fart/api/IdentifierFixerConfig.java
+++ b/src/main/java/net/minecraftforge/fart/api/IdentifierFixerConfig.java
@@ -20,7 +20,7 @@
 package net.minecraftforge.fart.api;
 
 /**
- * Identifier transformation strategy for {@link Transformer#createIdentifierFixer(IdentifierFixerConfig)}.
+ * Identifier transformation strategy for {@link Transformer#identifierFixerFactory(IdentifierFixerConfig)}.
  */
 public enum IdentifierFixerConfig {
     /**

--- a/src/main/java/net/minecraftforge/fart/api/IdentifierFixerConfig.java
+++ b/src/main/java/net/minecraftforge/fart/api/IdentifierFixerConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Forge Auto Renaming Tool
+ * Copyright (c) 2021
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fart.api;
+
+/**
+ * Identifier transformation strategy for {@link Transformer#createIdentifierFixer(IdentifierFixerConfig)}.
+ */
+public enum IdentifierFixerConfig {
+    /**
+     * Checks all Local variables if they are valid java identifiers.
+     */
+    ALL,
+    /**
+     * Only replaces snowman character used by Minecraft.
+     */
+    SNOWMEN;
+}

--- a/src/main/java/net/minecraftforge/fart/api/Inheritance.java
+++ b/src/main/java/net/minecraftforge/fart/api/Inheritance.java
@@ -22,12 +22,19 @@ package net.minecraftforge.fart.api;
 import java.io.File;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import net.minecraftforge.fart.internal.InheritanceImpl;
 
+import static java.util.Objects.requireNonNull;
+
 public interface Inheritance {
     static Inheritance create() {
-        return new InheritanceImpl();
+        return new InheritanceImpl(System.out::println);
+    }
+
+    static Inheritance create(Consumer<String> out) {
+        return new InheritanceImpl(requireNonNull(out));
     }
 
     void addLibrary(File path);

--- a/src/main/java/net/minecraftforge/fart/api/Renamer.java
+++ b/src/main/java/net/minecraftforge/fart/api/Renamer.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.fart.api;
 
 import java.io.File;
+import java.util.function.Consumer;
 
 import net.minecraftforge.fart.internal.RenamerBuilder;
 
@@ -36,7 +37,10 @@ public interface Renamer {
         Builder lib(File value);
         Builder map(File value);
         Builder add(Transformer value);
+        Builder add(Transformer.Factory factory);
         Builder threads(int value);
+        Builder logger(Consumer<String> out);
+        Builder debug(Consumer<String> debug);
         Renamer build();
     }
 }

--- a/src/main/java/net/minecraftforge/fart/api/SourceFixerConfig.java
+++ b/src/main/java/net/minecraftforge/fart/api/SourceFixerConfig.java
@@ -20,7 +20,7 @@
 package net.minecraftforge.fart.api;
 
 /**
- * Source file naming strategy for {@link Transformer#createSourceFixer(SourceFixerConfig)}.
+ * Source file naming strategy for {@link Transformer#sourceFixerFactory(SourceFixerConfig)}.
  */
 public enum SourceFixerConfig {
     // Uses java style Source file names, this means inner classes get the parent, and it uses a .java extension.

--- a/src/main/java/net/minecraftforge/fart/api/SourceFixerConfig.java
+++ b/src/main/java/net/minecraftforge/fart/api/SourceFixerConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Forge Auto Renaming Tool
+ * Copyright (c) 2021
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fart.api;
+
+/**
+ * Source file naming strategy for {@link Transformer#createSourceFixer(SourceFixerConfig)}.
+ */
+public enum SourceFixerConfig {
+    // Uses java style Source file names, this means inner classes get the parent, and it uses a .java extension.
+    JAVA;
+    // If people care they can PR scala/kotlin/groovy, or map based support
+}

--- a/src/main/java/net/minecraftforge/fart/api/Transformer.java
+++ b/src/main/java/net/minecraftforge/fart/api/Transformer.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fart.api;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Consumer;
 
 import net.minecraftforge.fart.internal.FFLineFixer;
 import net.minecraftforge.fart.internal.IdentifierFixer;
@@ -31,6 +32,8 @@ import net.minecraftforge.fart.internal.RecordFixer;
 import net.minecraftforge.fart.internal.RenamingTransformer;
 import net.minecraftforge.fart.internal.SourceFixer;
 import net.minecraftforge.srgutils.IMappingFile;
+
+import static java.util.Objects.requireNonNull;
 
 public interface Transformer {
     default ClassEntry process(ClassEntry entry) {
@@ -52,9 +55,21 @@ public interface Transformer {
      * @param inh inheritance information, including remapping classpath
      * @param map the mapping information to remap with
      * @return a renaming transformer
+     * @deprecated use {@link #renamerFactory(IMappingFile)} instead
      */
+    @Deprecated
     public static Transformer createRenamer(Inheritance inh, IMappingFile map) {
-        return new RenamingTransformer(inh, map);
+        return new RenamingTransformer(inh, map, System.out::println);
+    }
+
+    /**
+     * Create a transformer that applies mappings as a transformation.
+     *
+     * @param map the mapping information to remap with
+     * @return a factory for a renaming transformer
+     */
+    public static Factory renamerFactory(IMappingFile map) {
+        return ctx -> new RenamingTransformer(ctx.getInheritance(), map, ctx.getLog());
     }
 
     /**
@@ -70,29 +85,29 @@ public interface Transformer {
     /**
      * Create a transformer that fixes misaligned parameter annotations caused by Proguard.
      *
-     * @return a parameter annotation-fixing transformer
+     * @return a factory for a parameter annotation-fixing transformer
      */
-    public static Transformer createParameterAnnotationFixer() {
-        return ParameterAnnotationFixer.INSTANCE;
+    public static Factory parameterAnnotationFixerFactory() {
+        return ctx -> new ParameterAnnotationFixer(ctx.getLog(), ctx.getDebug());
     }
 
     /**
      * Create a transformer that applies line number corrections from Fernflower.
      *
      * @param sourceJar the source jar
-     * @return a transformer that applies line number information
+     * @return a factory for a transformer that applies line number information
      */
-    public static Transformer createFernFlowerLineFixer(File sourceJar) {
-        return new FFLineFixer(sourceJar);
+    public static Factory fernFlowerLineFixerFactory(File sourceJar) {
+        return ctx -> new FFLineFixer(ctx.getDebug(), sourceJar);
     }
 
     /**
      * Create a transformer that restores record component data stripped by ProGuard.
      *
-     * @return a transformer that fixes record class metadata
+     * @return a factory for a transformer that fixes record class metadata
      */
-    public static Transformer createRecordFixer() {
-        return RecordFixer.INSTANCE;
+    public static Factory recordFixerFactory() {
+        return ctx -> RecordFixer.INSTANCE;
     }
 
     /**
@@ -103,8 +118,8 @@ public interface Transformer {
      * @param config the method to use to generate a source file name.
      * @return a transformer that fixes {@code SourceFile} information
      */
-    public static Transformer createSourceFixer(SourceFixerConfig config) {
-        return new SourceFixer(config);
+    public static Factory sourceFixerFactory(SourceFixerConfig config) {
+        return ctx -> new SourceFixer(config);
     }
 
     public interface Entry {
@@ -138,5 +153,49 @@ public interface Transformer {
         static ManifestEntry create(long time, byte[] data) {
             return new EntryImpl.ManifestEntry(time, data);
         }
+    }
+
+    /**
+     * A factory to create transformers using {@link Renamer} instance-specific information.
+     */
+    public interface Factory {
+        /**
+         * Create a new factory that always returns the same transformer instance.
+         *
+         * @param transformer the transformer
+         * @return a new transformer factory
+         */
+        public static Factory always(final Transformer transformer) {
+            requireNonNull(transformer, "transformer");
+            return ctx -> transformer;
+        }
+
+        /**
+         * Create a new transformer.
+         *
+         * @param ctx context
+         * @return a transformer instance
+         */
+        Transformer create(Context ctx);
+    }
+
+    /**
+     * Context providing renamer state when creating a transformer.
+     */
+    public interface Context {
+        /**
+         * Get a consumer that will handle standard-level logging output.
+         *
+         * @return the logging handler
+         */
+        Consumer<String> getLog();
+
+        /**
+         * Get a consumer that will handle debug-level logging output.
+         *
+         * @return the debug logging handler
+         */
+        Consumer<String> getDebug();
+        Inheritance getInheritance();
     }
 }

--- a/src/main/java/net/minecraftforge/fart/api/Transformer.java
+++ b/src/main/java/net/minecraftforge/fart/api/Transformer.java
@@ -19,11 +19,17 @@
 
 package net.minecraftforge.fart.api;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 
+import net.minecraftforge.fart.internal.FFLineFixer;
+import net.minecraftforge.fart.internal.IdentifierFixer;
+import net.minecraftforge.fart.internal.ParameterAnnotationFixer;
 import net.minecraftforge.fart.internal.EntryImpl;
+import net.minecraftforge.fart.internal.RecordFixer;
 import net.minecraftforge.fart.internal.RenamingTransformer;
+import net.minecraftforge.fart.internal.SourceFixer;
 import net.minecraftforge.srgutils.IMappingFile;
 
 public interface Transformer {
@@ -40,8 +46,65 @@ public interface Transformer {
         return Collections.emptyList();
     }
 
+    /**
+     * Create a transformer that applies mappings as a transformation.
+     *
+     * @param inh inheritance information, including remapping classpath
+     * @param map the mapping information to remap with
+     * @return a renaming transformer
+     */
     public static Transformer createRenamer(Inheritance inh, IMappingFile map) {
         return new RenamingTransformer(inh, map);
+    }
+
+    /**
+     * Create a transformer that renames any local variables that are not valid java identifiers.
+     *
+     * @param config option for which local variables to rename
+     * @return an identifier-fixing transformer
+     */
+    public static Transformer createIdentifierFixer(final IdentifierFixerConfig config) {
+        return new IdentifierFixer(config);
+    }
+
+    /**
+     * Create a transformer that fixes misaligned parameter annotations caused by Proguard.
+     *
+     * @return a parameter annotation-fixing transformer
+     */
+    public static Transformer createParameterAnnotationFixer() {
+        return ParameterAnnotationFixer.INSTANCE;
+    }
+
+    /**
+     * Create a transformer that applies line number corrections from Fernflower.
+     *
+     * @param sourceJar the source jar
+     * @return a transformer that applies line number information
+     */
+    public static Transformer createFernFlowerLineFixer(File sourceJar) {
+        return new FFLineFixer(sourceJar);
+    }
+
+    /**
+     * Create a transformer that restores record component data stripped by ProGuard.
+     *
+     * @return a transformer that fixes record class metadata
+     */
+    public static Transformer createRecordFixer() {
+        return RecordFixer.INSTANCE;
+    }
+
+    /**
+     * Create a transformer that fixes the {@code SourceFile} attribute of classes.
+     *
+     * This attempts to infer a file name based on the supplied language information.
+     *
+     * @param config the method to use to generate a source file name.
+     * @return a transformer that fixes {@code SourceFile} information
+     */
+    public static Transformer createSourceFixer(SourceFixerConfig config) {
+        return new SourceFixer(config);
     }
 
     public interface Entry {

--- a/src/main/java/net/minecraftforge/fart/api/Transformer.java
+++ b/src/main/java/net/minecraftforge/fart/api/Transformer.java
@@ -78,8 +78,8 @@ public interface Transformer {
      * @param config option for which local variables to rename
      * @return an identifier-fixing transformer
      */
-    public static Transformer createIdentifierFixer(final IdentifierFixerConfig config) {
-        return new IdentifierFixer(config);
+    public static Factory identifierFixerFactory(final IdentifierFixerConfig config) {
+        return ctx -> new IdentifierFixer(config);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/fart/internal/EnhancedRemapper.java
+++ b/src/main/java/net/minecraftforge/fart/internal/EnhancedRemapper.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
@@ -44,10 +45,12 @@ class EnhancedRemapper extends Remapper {
     private final Inheritance inh;
     private final IMappingFile map;
     private final Map<String, Optional<MClass>> resolved = new ConcurrentHashMap<>();
+    private final Consumer<String> log;
 
-    public EnhancedRemapper(Inheritance inh, IMappingFile map) {
+    public EnhancedRemapper(Inheritance inh, IMappingFile map, Consumer<String> log) {
         this.inh = inh;
         this.map = map;
+        this.log = log;
     }
 
     @Override public String mapModuleName(final String name) { return name; } // TODO? None of the mapping formats support this.
@@ -133,10 +136,6 @@ class EnhancedRemapper extends Remapper {
         private Collection<Optional<MField>> fieldsView = Collections.unmodifiableCollection(fields.values());
         private final Map<String, Optional<MMethod>> methods = new ConcurrentHashMap<>();
         private Collection<Optional<MMethod>> methodsView = Collections.unmodifiableCollection(methods.values());
-
-        private void log(String line) {
-            System.out.println(line);
-        }
 
         MClass(IClassInfo icls, IMappingFile.IClass mcls) {
             if (icls == null && mcls == null)
@@ -252,7 +251,7 @@ class EnhancedRemapper extends Remapper {
                         MMethod existing = existingO.orElse(null);
                         if (!existing.hasMapping() && !existing.getName().equals(mtd.getMapped())) {
                             if (!existing.getMapped().equals(mtd.getMapped()))
-                                log("Conflictig propagated mapping for " + existing + " from " + mtd + ": " + existing.getMapped() + " -> " + mtd.getMapped());
+                                log.accept("Conflictig propagated mapping for " + existing + " from " + mtd + ": " + existing.getMapped() + " -> " + mtd.getMapped());
                             existing.setMapped(mtd.getMapped());
                         }
                         /*
@@ -273,7 +272,7 @@ class EnhancedRemapper extends Remapper {
                          */
                         else if (!mtd.hasMapping() && !mtd.getName().equals(existing.getMapped())) {
                             if (!mtd.getMapped().equals(existing.getMapped()))
-                                log("Conflictig propagated mapping for " + mtd + " from " + existing + ": " + mtd.getMapped() + " -> " + existing.getMapped());
+                                log.accept("Conflictig propagated mapping for " + mtd + " from " + existing + ": " + mtd.getMapped() + " -> " + existing.getMapped());
                             mtd.setMapped(existing.getMapped());
                         }
                     }

--- a/src/main/java/net/minecraftforge/fart/internal/FFLineFixer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/FFLineFixer.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.fart;
+package net.minecraftforge.fart.internal;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,10 +37,10 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import net.minecraftforge.fart.api.Transformer;
 
-class FFLineFixer implements Transformer {
-    private Map<String, NavigableMap<Integer, Integer>> classes = new HashMap<>();
+public final class FFLineFixer implements Transformer {
+    private final Map<String, NavigableMap<Integer, Integer>> classes = new HashMap<>();
 
-    FFLineFixer(File data) {
+    public FFLineFixer(File data) {
         try (FileInputStream fis = new FileInputStream(data);
             ZipInputStream zip = new ZipInputStream(fis)) {
             ZipEntry entry = null;
@@ -107,12 +107,12 @@ class FFLineFixer implements Transformer {
         return ClassEntry.create(entry.getName(), entry.getTime(), writer.toByteArray());
     }
 
-    private class Fixer extends ClassVisitor {
+    private static class Fixer extends ClassVisitor {
         private final NavigableMap<Integer, Integer> lines;
         private boolean madeChange = false;
 
         public Fixer(ClassVisitor parent, NavigableMap<Integer, Integer> lines) {
-            super(Main.MAX_ASM_VERSION, parent);
+            super(RenamerImpl.MAX_ASM_VERSION, parent);
             this.lines = lines;
         }
 
@@ -123,7 +123,7 @@ class FFLineFixer implements Transformer {
         @Override
         public final MethodVisitor visitMethod(final int access, final String name, final String descriptor, final String signature, final String[] exceptions) {
             MethodVisitor parent = super.visitMethod(access, name, descriptor, signature, exceptions);
-            return new MethodVisitor(Main.MAX_ASM_VERSION, parent) {
+            return new MethodVisitor(RenamerImpl.MAX_ASM_VERSION, parent) {
                 @Override
                 public void visitLineNumber(final int line, final Label start) {
                     Map.Entry<Integer, Integer> nline = lines.higherEntry(line);

--- a/src/main/java/net/minecraftforge/fart/internal/FFLineFixer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/FFLineFixer.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -40,7 +41,7 @@ import net.minecraftforge.fart.api.Transformer;
 public final class FFLineFixer implements Transformer {
     private final Map<String, NavigableMap<Integer, Integer>> classes = new HashMap<>();
 
-    public FFLineFixer(File data) {
+    public FFLineFixer(Consumer<String> debug, File data) {
         try (FileInputStream fis = new FileInputStream(data);
             ZipInputStream zip = new ZipInputStream(fis)) {
             ZipEntry entry = null;
@@ -57,7 +58,7 @@ public final class FFLineFixer implements Transformer {
                     short len = buf.getShort();
                     if (id == 0x4646) { //FF
                         String cls = entry.getName().substring(0, entry.getName().length() - 5);
-                        log("Lines: " + cls);
+                        debug.accept("Lines: " + cls);
                         int ver = buf.get();
                         if (ver != 1)
                             throw new IllegalStateException("Invalid FF code line version for " + entry.getName());
@@ -66,7 +67,7 @@ public final class FFLineFixer implements Transformer {
                         for (int x = 0; x < count; x++) {
                             int oline = buf.getShort();
                             int nline = buf.getShort();
-                            log("  " + oline + ' ' + nline);
+                            debug.accept("  " + oline + ' ' + nline);
                             lines.put(oline, nline);
                         }
                         classes.put(cls, lines);
@@ -78,10 +79,6 @@ public final class FFLineFixer implements Transformer {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private static void log(String line) {
-        //System.out.println(line);
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/fart/internal/IdentifierFixer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/IdentifierFixer.java
@@ -17,35 +17,25 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.fart;
+package net.minecraftforge.fart.internal;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.objectweb.asm.ClassReader;
+import net.minecraftforge.fart.api.IdentifierFixerConfig;
 import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 
-import net.minecraftforge.fart.api.Transformer;
-
-class IdentifierFixer extends OptionalChangeTransformer {
-    enum Config {
-        // Checks all Local variables if they are valid java identifiers.
-        ALL,
-        // Only replaces snowman character used by Minecraft
-        SNOWMEN;
-    }
-
-    IdentifierFixer(Config config) {
+public final class IdentifierFixer extends OptionalChangeTransformer {
+    public IdentifierFixer(IdentifierFixerConfig config) {
         super(parent -> new Fixer(config, parent));
     }
 
     private static class Fixer extends ClassFixer {
-        private final Config config;
+        private final IdentifierFixerConfig config;
 
-        public Fixer(Config config, ClassVisitor parent) {
+        public Fixer(IdentifierFixerConfig config, ClassVisitor parent) {
             super(parent);
             this.config = config;
         }
@@ -57,7 +47,7 @@ class IdentifierFixer extends OptionalChangeTransformer {
         @Override
         public final MethodVisitor visitMethod(final int access, final String name, final String descriptor, final String signature, final String[] exceptions) {
             MethodVisitor parent = super.visitMethod(access, name, descriptor, signature, exceptions);
-            return new MethodVisitor(Main.MAX_ASM_VERSION, parent) {
+            return new MethodVisitor(RenamerImpl.MAX_ASM_VERSION, parent) {
                 @Override
                 public void visitLocalVariable(final String pname, final String pdescriptor, final String psignature, final Label start, final Label end, final int index) {
                     String newName = fixName(pname, index);
@@ -69,7 +59,7 @@ class IdentifierFixer extends OptionalChangeTransformer {
                     boolean valid = true;
                     if (name.isEmpty()) {
                         valid = false;
-                    } else if (config == Config.SNOWMEN) {
+                    } else if (config == IdentifierFixerConfig.SNOWMEN) {
                         // Snowmen, added in 1.8.2? rename them names that can exist in source
                         if ((char)0x2603 == name.charAt(0))
                             valid = false;

--- a/src/main/java/net/minecraftforge/fart/internal/InheritanceImpl.java
+++ b/src/main/java/net/minecraftforge/fart/internal/InheritanceImpl.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,8 +51,13 @@ import org.objectweb.asm.tree.MethodNode;
 import net.minecraftforge.fart.api.Inheritance;
 
 public class InheritanceImpl implements Inheritance {
+    private final Consumer<String> log;
     private Map<String, File> sources = new HashMap<>();
     private Map<String, Optional<ClassInfo>> classes = new ConcurrentHashMap<>();
+
+    public InheritanceImpl(Consumer<String> log) {
+        this.log = log;
+    }
 
     @Override
     public void addLibrary(File path) {
@@ -95,14 +101,10 @@ public class InheritanceImpl implements Inheritance {
                 Class<?> cls = Class.forName(name.replace('/', '.'), false, this.getClass().getClassLoader());
                 return Optional.of(new ClassInfo(cls));
             } catch (ClassNotFoundException ex) {
-                log("Cant Find Class: " + name);
+                log.accept("Cant Find Class: " + name);
                 return Optional.empty();
             }
         }
-    }
-
-    private void log(String line) {
-        System.out.println(line);
     }
 
     private static class ClassInfo implements IClassInfo {

--- a/src/main/java/net/minecraftforge/fart/internal/OptionalChangeTransformer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/OptionalChangeTransformer.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.fart;
+package net.minecraftforge.fart.internal;
 
 import net.minecraftforge.fart.api.Transformer;
 import org.objectweb.asm.ClassReader;
@@ -51,7 +51,7 @@ abstract class OptionalChangeTransformer implements Transformer {
         protected boolean madeChange = false;
 
         protected ClassFixer(ClassVisitor parent) {
-            this(Main.MAX_ASM_VERSION, parent);
+            this(RenamerImpl.MAX_ASM_VERSION, parent);
         }
 
         protected ClassFixer(int api, ClassVisitor classVisitor) {

--- a/src/main/java/net/minecraftforge/fart/internal/ParameterAnnotationFixer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/ParameterAnnotationFixer.java
@@ -23,6 +23,8 @@ import static org.objectweb.asm.Opcodes.*;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
+
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -35,9 +37,12 @@ import org.objectweb.asm.tree.MethodNode;
 import net.minecraftforge.fart.api.Transformer;
 
 public final class ParameterAnnotationFixer implements Transformer {
-    public static final ParameterAnnotationFixer INSTANCE = new ParameterAnnotationFixer();
+    private final Consumer<String> log;
+    private final Consumer<String> debug;
 
-    private ParameterAnnotationFixer() {
+    public ParameterAnnotationFixer(Consumer<String> log, Consumer<String> debug) {
+        this.log = log;
+        this.debug = debug;
     }
 
     @Override
@@ -50,7 +55,7 @@ public final class ParameterAnnotationFixer implements Transformer {
         return ClassEntry.create(entry.getName(), entry.getTime(), writer.toByteArray());
     }
 
-    private static class Visitor extends ClassVisitor {
+    private class Visitor extends ClassVisitor {
         private final ClassNode node;
 
         public Visitor(ClassNode cn) {
@@ -59,11 +64,11 @@ public final class ParameterAnnotationFixer implements Transformer {
         }
 
         private void debug(String message) {
-            //System.out.println(message);
+            debug.accept(message);
         }
 
         private void log(String message) {
-            System.out.println(message);
+            log.accept(message);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/fart/internal/ParameterAnnotationFixer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/ParameterAnnotationFixer.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.fart;
+package net.minecraftforge.fart.internal;
 
 import static org.objectweb.asm.Opcodes.*;
 
@@ -34,7 +34,12 @@ import org.objectweb.asm.tree.MethodNode;
 
 import net.minecraftforge.fart.api.Transformer;
 
-public class ParameterAnnotationFixer implements Transformer {
+public final class ParameterAnnotationFixer implements Transformer {
+    public static final ParameterAnnotationFixer INSTANCE = new ParameterAnnotationFixer();
+
+    private ParameterAnnotationFixer() {
+    }
+
     @Override
     public ClassEntry process(ClassEntry entry) {
         final ClassReader reader = new ClassReader(entry.getData());
@@ -49,7 +54,7 @@ public class ParameterAnnotationFixer implements Transformer {
         private final ClassNode node;
 
         public Visitor(ClassNode cn) {
-            super(Main.MAX_ASM_VERSION, cn);
+            super(RenamerImpl.MAX_ASM_VERSION, cn);
             this.node = cn;
         }
 

--- a/src/main/java/net/minecraftforge/fart/internal/RecordFixer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/RecordFixer.java
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.fart;
+package net.minecraftforge.fart.internal;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -27,8 +27,10 @@ import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.RecordComponentVisitor;
 
-class RecordFixer extends OptionalChangeTransformer {
-    protected RecordFixer() {
+public class RecordFixer extends OptionalChangeTransformer {
+    public static final RecordFixer INSTANCE = new RecordFixer();
+
+    private RecordFixer() {
         super(Fixer::new);
     }
 

--- a/src/main/java/net/minecraftforge/fart/internal/RenamerImpl.java
+++ b/src/main/java/net/minecraftforge/fart/internal/RenamerImpl.java
@@ -26,8 +26,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -51,25 +51,29 @@ class RenamerImpl implements Renamer {
     private final List<Transformer> transformers;
     private final Inheritance inh;
     private final int threads;
+    private final Consumer<String> logger;
+    private final Consumer<String> debug;
 
-    RenamerImpl(File input, File output, List<File> libraries, List<Transformer> transformers, Inheritance inh, int threads) {
+    RenamerImpl(File input, File output, List<File> libraries, List<Transformer> transformers, Inheritance inh, int threads, Consumer<String> logger, Consumer<String> debug) {
         this.input = input.getAbsoluteFile();
         this.output = output.getAbsoluteFile();
         this.libraries = libraries;
         this.transformers = transformers;
         this.inh = inh;
         this.threads = threads;
+        this.logger = logger;
+        this.debug = debug;
     }
 
     @Override
     public void run() {
-        log("Adding Libraries to Inheritance");
+        logger.accept("Adding Libraries to Inheritance");
         libraries.forEach(inh::addLibrary);
 
         if (!input.exists())
             throw new IllegalArgumentException("Input file not found: " + input.getAbsolutePath());
 
-        log("Reading Input: " + input.getAbsolutePath());
+        logger.accept("Reading Input: " + input.getAbsolutePath());
         // Read everything from the input jar!
         List<Entry> oldEntries = new ArrayList<>();
         try (ZipFile in = new ZipFile(input)) {
@@ -107,16 +111,16 @@ class RenamerImpl implements Renamer {
                 .collect(Collectors.toList());
 
             // Add the original classes to the inheritance map, TODO: Multi-Release somehow?
-            log("Adding input to inheritence map");
+            logger.accept("Adding input to inheritence map");
             async.consumeAll(ourClasses, c ->
                 inh.addClass(c.getName().substring(0, c.getName().length() - 6), c.getData())
             );
 
             // Process everything
-            log("Processing entries");
+            logger.accept("Processing entries");
             List<Entry> newEntries = async.invokeAll(oldEntries, this::processEntry);
 
-            log("Adding extras");
+            logger.accept("Adding extras");
             transformers.stream().forEach(t -> newEntries.addAll(t.getExtras()));
 
             Set<String> seen = new HashSet<>();
@@ -135,14 +139,14 @@ class RenamerImpl implements Renamer {
             */
 
             // We care about stable output, so sort, and single thread write.
-            log("Sorting");
+            logger.accept("Sorting");
             Collections.sort(newEntries, this::compare);
 
             if (!output.getParentFile().exists())
                 output.getParentFile().mkdirs();
 
             seen.clear();
-            log("Writing Output: " + output.getAbsolutePath());
+            logger.accept("Writing Output: " + output.getAbsolutePath());
             try (FileOutputStream fos = new FileOutputStream(output);
                 ZipOutputStream zos = new ZipOutputStream(fos)) {
 
@@ -152,7 +156,7 @@ class RenamerImpl implements Renamer {
                     if (idx != -1)
                         addDirectory(zos, seen, name.substring(0, idx));
 
-                    log("  " + name);
+                    logger.accept("  " + name);
                     ZipEntry entry = new ZipEntry(name);
                     entry.setTime(e.getTime());
                     zos.putNextEntry(entry);
@@ -177,15 +181,11 @@ class RenamerImpl implements Renamer {
         if (idx != -1)
             addDirectory(zos, seen, path.substring(0, idx));
 
-        log("  " + path + '/');
+        logger.accept("  " + path + '/');
         ZipEntry dir = new ZipEntry(path + '/');
         dir.setTime(Entry.STABLE_TIMESTAMP);
         zos.putNextEntry(dir);
         zos.closeEntry();
-    }
-
-    private void log(String line) {
-        System.out.println(line);
     }
 
     private Entry processEntry(final Entry start) {

--- a/src/main/java/net/minecraftforge/fart/internal/RenamerImpl.java
+++ b/src/main/java/net/minecraftforge/fart/internal/RenamerImpl.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
+import org.objectweb.asm.Opcodes;
 
 import net.minecraftforge.fart.api.Inheritance;
 import net.minecraftforge.fart.api.Renamer;
@@ -42,6 +43,7 @@ import net.minecraftforge.fart.api.Transformer.ManifestEntry;
 import net.minecraftforge.fart.api.Transformer.ResourceEntry;
 
 class RenamerImpl implements Renamer {
+    static final int MAX_ASM_VERSION = Opcodes.ASM9;
     private static final String MANIFEST_NAME = "META-INF/MANIFEST.MF";
     private final File input;
     private final File output;

--- a/src/main/java/net/minecraftforge/fart/internal/RenamingTransformer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/RenamingTransformer.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.objectweb.asm.ClassReader;
@@ -40,8 +41,8 @@ public class RenamingTransformer implements Transformer {
     private final EnhancedRemapper remapper;
     private final Set<String> abstractParams = ConcurrentHashMap.newKeySet();
 
-    public RenamingTransformer(Inheritance inh, IMappingFile map) {
-        this.remapper = new EnhancedRemapper(inh, map);
+    public RenamingTransformer(Inheritance inh, IMappingFile map, Consumer<String> log) {
+        this.remapper = new EnhancedRemapper(inh, map, log);
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/fart/internal/SourceFixer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/SourceFixer.java
@@ -17,27 +17,23 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.fart;
+package net.minecraftforge.fart.internal;
 
+import net.minecraftforge.fart.api.SourceFixerConfig;
 import org.objectweb.asm.ClassVisitor;
 
-public class SourceFixer extends OptionalChangeTransformer {
-    enum Config {
-        // Uses java style Source file names, this means inner classes get the parent, and it uses a .java extension.
-        JAVA;
-        // If people care they can PR scala/kotlin/groovy, or map based support
-    }
+public final class SourceFixer extends OptionalChangeTransformer {
 
-    SourceFixer(Config config) {
+    public SourceFixer(SourceFixerConfig config) {
         super(parent -> new Fixer(config, parent));
     }
 
     private static class Fixer extends ClassFixer {
-        private final Config config;
+        private final SourceFixerConfig config;
         private String className = null;
         private boolean hadEntry = false;
 
-        public Fixer(Config config, ClassVisitor parent) {
+        public Fixer(SourceFixerConfig config, ClassVisitor parent) {
             super(parent);
             this.config = config;
         }
@@ -60,7 +56,7 @@ public class SourceFixer extends OptionalChangeTransformer {
 
         private String getSourceName(String existing) {
             String name = className;
-            if (config == Config.JAVA) {
+            if (config == SourceFixerConfig.JAVA) {
                 int idx = name.lastIndexOf('/');
                 if (idx != -1)
                     name = name.substring(idx + 1);


### PR DESCRIPTION
For Sponge's tooling, we use FART's API directly rather than the CLI, which allows contributing extra (custom) transformers to our remap operations. However, none of the 'fixer' transformers were exposed to the API, and the remapping transformer could only be created by calling `map(File)` on `Renamer.Builder`, since the builder's `Inheritance` was not exposed.

We also want to be able to redirect logging, to be able to run FART from within a Gradle process where Gradle has its own logging setup, so logging should not depend on global state.

To enable these two goals, I've restructured the `Transformer` creation process to pass semi-private state such as inheritance and logging callbacks through to transformers. While the `Context` object used here adds a layer of indirection, I think it's necessary to avoid future API breaks if additional parameters need to be passed to some transformers, and lets transformers that don't need many of the parameters available just ignore unused parameters.