### PR TITLE
Use bytecode information for staticness, not tsrg2 metadata

### DIFF
--- a/src/main/java/net/minecraftforge/fart/internal/EnhancedRemapper.java
+++ b/src/main/java/net/minecraftforge/fart/internal/EnhancedRemapper.java
@@ -376,7 +376,7 @@ class EnhancedRemapper extends Remapper {
                 this.mmtd = mmtd;
                 if (mmtd != null && !mmtd.getDescriptor().contains("()")) {
                     List<String> tmp = new ArrayList<>();
-                    if (!mmtd.getMetadata().containsKey("is_static"))
+                    if ((imtd.getAccess() & ACC_STATIC) == 0)
                         tmp.add("this");
 
                     Type[] args = Type.getArgumentTypes(mmtd.getDescriptor());


### PR DESCRIPTION
Many mapping formats (in my usecase, Mojang's official proguard dumps) don't provide staticness info, so this check was incorrectly naming the first parameter of static methods `this`, and shifting all following parameter mappings one parameter to the right.

This can be fixed by using bytecode information rather than mappings metadata.