### PR TITLE
Fix record fields not being made private

### DIFF
--- a/src/main/java/net/minecraftforge/fart/RecordFixer.java
+++ b/src/main/java/net/minecraftforge/fart/RecordFixer.java
@@ -59,7 +59,11 @@ class RecordFixer extends OptionalChangeTransformer {
             // These fields still need to have record components generated, so we need to ignore ACC_PRIVATE.
             if (isRecord && (access & (Opcodes.ACC_FINAL | Opcodes.ACC_STATIC)) == Opcodes.ACC_FINAL) {
                 // Make sure the visibility gets set back to private
-                access = access & ~(Opcodes.ACC_PUBLIC | Opcodes.ACC_PROTECTED) | Opcodes.ACC_PRIVATE;
+                int newAccess = access & ~(Opcodes.ACC_PUBLIC | Opcodes.ACC_PROTECTED) | Opcodes.ACC_PRIVATE;
+                if (newAccess != access) {
+                    this.madeChange = true;
+                    access = newAccess;
+                }
                 // Manually add the record component back if this class doesn't have any
                 if (components == null)
                     components = new LinkedHashMap<String, Entry>();


### PR DESCRIPTION
Record fields are now made private even if record components already exist.

[Diff on 1.18-pre6](https://github.com/SizableShrimp/MCPConfig/commit/80843b3f8481c4c2676a05df6008419968c59680)