### PR TITLE
Strip code-signing signatures from classes when remapping

### DIFF
--- a/src/main/java/net/minecraftforge/fart/api/SignatureStripperConfig.java
+++ b/src/main/java/net/minecraftforge/fart/api/SignatureStripperConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Forge Auto Renaming Tool
+ * Copyright (c) 2021
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fart.api;
+
+public enum SignatureStripperConfig {
+    ALL;
+    // INVALID_ONLY could be implemented if desired
+}

--- a/src/main/java/net/minecraftforge/fart/api/Transformer.java
+++ b/src/main/java/net/minecraftforge/fart/api/Transformer.java
@@ -30,6 +30,7 @@ import net.minecraftforge.fart.internal.ParameterAnnotationFixer;
 import net.minecraftforge.fart.internal.EntryImpl;
 import net.minecraftforge.fart.internal.RecordFixer;
 import net.minecraftforge.fart.internal.RenamingTransformer;
+import net.minecraftforge.fart.internal.SignatureStripperTransformer;
 import net.minecraftforge.fart.internal.SourceFixer;
 import net.minecraftforge.srgutils.IMappingFile;
 
@@ -120,6 +121,16 @@ public interface Transformer {
      */
     public static Factory sourceFixerFactory(SourceFixerConfig config) {
         return ctx -> new SourceFixer(config);
+    }
+
+    /**
+     * Create a transformer that strips invalid code signing signatures from a manifest.
+     *
+     * @param config the variants of signatures to strip
+     * @return a factory for a transformer that strips signatures
+     */
+    public static Factory signatureStripperFactory(SignatureStripperConfig config) {
+        return ctx -> new SignatureStripperTransformer(ctx.getLog(), config);
     }
 
     public interface Entry {

--- a/src/main/java/net/minecraftforge/fart/internal/RenamingTransformer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/RenamingTransformer.java
@@ -19,13 +19,20 @@
 
 package net.minecraftforge.fart.internal;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
 import org.objectweb.asm.ClassReader;
@@ -37,12 +44,15 @@ import net.minecraftforge.fart.api.Transformer;
 import net.minecraftforge.srgutils.IMappingFile;
 
 public class RenamingTransformer implements Transformer {
+    private static final Attributes.Name SHA_256_DIGEST = new Attributes.Name("SHA-256-Digest");
     private static final String ABSTRACT_FILE = "fernflower_abstract_parameter_names.txt";
     private final EnhancedRemapper remapper;
     private final Set<String> abstractParams = ConcurrentHashMap.newKeySet();
+    private final Consumer<String> log;
 
     public RenamingTransformer(Inheritance inh, IMappingFile map, Consumer<String> log) {
         this.remapper = new EnhancedRemapper(inh, map, log);
+        this.log = log;
     }
 
     @Override
@@ -63,6 +73,28 @@ public class RenamingTransformer implements Transformer {
 
     @Override
     public ManifestEntry process(ManifestEntry entry) {
+        // Remove all signature entries
+        try {
+            final Manifest manifest = new Manifest(new ByteArrayInputStream(entry.getData()));
+            boolean found = false;
+            for (final Iterator<Map.Entry<String, Attributes>> it = manifest.getEntries().entrySet().iterator(); it.hasNext();) {
+                final Map.Entry<String, Attributes> section = it.next();
+                if (section.getValue().remove(SHA_256_DIGEST) != null) {
+                    if (section.getValue().isEmpty()) {
+                        it.remove();
+                    }
+                    found = true;
+                }
+            }
+            if (found) {
+                try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+                    manifest.write(os);
+                    return ManifestEntry.create(entry.getTime(), os.toByteArray());
+                }
+            }
+        } catch (final IOException ex) {
+            log.accept("Failed to remove signature entries from manifest: " + ex);
+        }
         return entry;
     }
 
@@ -70,6 +102,12 @@ public class RenamingTransformer implements Transformer {
     public ResourceEntry process(ResourceEntry entry) {
         if (ABSTRACT_FILE.equals(entry.getName()))
             return null;
+        if (entry.getName().startsWith("META-INF/")) {
+            if (entry.getName().endsWith(".RSA")
+                    || entry.getName().endsWith(".SF")) {
+                return null;
+            }
+        }
         return entry;
     }
 

--- a/src/main/java/net/minecraftforge/fart/internal/RenamingTransformer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/RenamingTransformer.java
@@ -19,21 +19,13 @@
 
 package net.minecraftforge.fart.internal;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
 import org.objectweb.asm.ClassReader;
@@ -45,15 +37,12 @@ import net.minecraftforge.fart.api.Transformer;
 import net.minecraftforge.srgutils.IMappingFile;
 
 public class RenamingTransformer implements Transformer {
-    private static final Attributes.Name SHA_256_DIGEST = new Attributes.Name("SHA-256-Digest");
     private static final String ABSTRACT_FILE = "fernflower_abstract_parameter_names.txt";
     private final EnhancedRemapper remapper;
     private final Set<String> abstractParams = ConcurrentHashMap.newKeySet();
-    private final Consumer<String> log;
 
     public RenamingTransformer(Inheritance inh, IMappingFile map, Consumer<String> log) {
         this.remapper = new EnhancedRemapper(inh, map, log);
-        this.log = log;
     }
 
     @Override
@@ -73,54 +62,10 @@ public class RenamingTransformer implements Transformer {
     }
 
     @Override
-    public ManifestEntry process(ManifestEntry entry) {
-        // Remove all signature entries
-        // see signed jar spec: https://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html#Signed_JAR_File
-        try {
-            final Manifest manifest = new Manifest(new ByteArrayInputStream(entry.getData()));
-            boolean found = false;
-            for (final Iterator<Map.Entry<String, Attributes>> it = manifest.getEntries().entrySet().iterator(); it.hasNext();) {
-                final Map.Entry<String, Attributes> section = it.next();
-                for (final Iterator<Map.Entry<Object, Object>> attrIter = section.getValue().entrySet().iterator(); attrIter.hasNext();) {
-                    final Map.Entry<Object, Object> attribute = attrIter.next();
-                    final String key = attribute.getKey().toString().toLowerCase(Locale.ROOT); // spec says this is case-insensitive
-                    if (key.endsWith("-digest")) { // assume that this is a signature entry
-                        attrIter.remove();
-                        found = true;
-                    }
-                    // keep going even if we've found an attribute -- multiple hash formats can be specified for each file
-                }
-
-                if (section.getValue().isEmpty()) {
-                    it.remove();
-                }
-            }
-            if (found) {
-                try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
-                    manifest.write(os);
-                    return ManifestEntry.create(entry.getTime(), os.toByteArray());
-                }
-            }
-        } catch (final IOException ex) {
-            log.accept("Failed to remove signature entries from manifest: " + ex);
-        }
-        return entry;
-    }
-
-    @Override
     public ResourceEntry process(ResourceEntry entry) {
         if (ABSTRACT_FILE.equals(entry.getName()))
             return null;
 
-        // Signature metadata
-        if (entry.getName().startsWith("META-INF/")) {
-            if (entry.getName().endsWith(".RSA")
-                    || entry.getName().endsWith(".SF")
-                    || entry.getName().endsWith(".DSA")
-                    || entry.getName().endsWith(".EC")) { // supported by InstallerRewriter but not referenced in the spec
-                return null;
-            }
-        }
         return entry;
     }
 

--- a/src/main/java/net/minecraftforge/fart/internal/SignatureStripperTransformer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/SignatureStripperTransformer.java
@@ -1,0 +1,94 @@
+/*
+ * Forge Auto Renaming Tool
+ * Copyright (c) 2021
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fart.internal;
+
+import net.minecraftforge.fart.api.SignatureStripperConfig;
+import net.minecraftforge.fart.api.Transformer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+public class SignatureStripperTransformer implements Transformer {
+    private final Consumer<String> log;
+    private final SignatureStripperConfig config;
+
+    public SignatureStripperTransformer(Consumer<String> log, SignatureStripperConfig config) {
+        this.log = log;
+        this.config = config;
+    }
+
+    @Override
+    public ManifestEntry process(ManifestEntry entry) {
+        // Remove all signature entries
+        // see signed jar spec: https://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html#Signed_JAR_File
+        try {
+            final Manifest manifest = new Manifest(new ByteArrayInputStream(entry.getData()));
+            boolean found = false;
+            for (final Iterator<Map.Entry<String, Attributes>> it = manifest.getEntries().entrySet().iterator(); it.hasNext();) {
+                final Map.Entry<String, Attributes> section = it.next();
+                for (final Iterator<Map.Entry<Object, Object>> attrIter = section.getValue().entrySet().iterator(); attrIter.hasNext();) {
+                    final Map.Entry<Object, Object> attribute = attrIter.next();
+                    final String key = attribute.getKey().toString().toLowerCase(Locale.ROOT); // spec says this is case-insensitive
+                    if (key.endsWith("-digest")) { // assume that this is a signature entry
+                        if (this.config == SignatureStripperConfig.ALL) {
+                            attrIter.remove();
+                        }
+                        found = true;
+                    }
+                    // keep going even if we've found an attribute -- multiple hash formats can be specified for each file
+                }
+
+                if (section.getValue().isEmpty()) {
+                    it.remove();
+                }
+            }
+            if (found) {
+                try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+                    manifest.write(os);
+                    return ManifestEntry.create(entry.getTime(), os.toByteArray());
+                }
+            }
+        } catch (final IOException ex) {
+            log.accept("Failed to remove signature entries from manifest: " + ex);
+        }
+        return entry;
+    }
+
+    @Override
+    public ResourceEntry process(ResourceEntry entry) {
+        // Signature metadata
+        if (entry.getName().startsWith("META-INF/")) {
+            if (entry.getName().endsWith(".RSA")
+                    || entry.getName().endsWith(".SF")
+                    || entry.getName().endsWith(".DSA")
+                    || entry.getName().endsWith(".EC")) { // supported by InstallerRewriter but not referenced in the spec
+                return null;
+            }
+        }
+        return entry;
+    }
+}


### PR DESCRIPTION
This is a port of signature-stripping code from VanillaGradle, with some modifications based on Lex's link to InstallerRewriter. 

I've lumped it into the renaming transformer here, but it might make sense to split it off into a separate transformer since it could theoretically be used independently.