### PR TITLE
Properly handle situations where only mappings metadata is available

### DIFF
--- a/src/main/java/net/minecraftforge/fart/internal/EnhancedRemapper.java
+++ b/src/main/java/net/minecraftforge/fart/internal/EnhancedRemapper.java
@@ -397,9 +397,15 @@ class EnhancedRemapper extends Remapper {
                 this.mmtd = mmtd;
                 if (mmtd != null && !mmtd.getDescriptor().contains("()")) {
                     List<String> tmp = new ArrayList<>();
-                    if ((imtd.getAccess() & ACC_STATIC) == 0)
+                    boolean isStatic;
+                    if (imtd != null) {
+                        isStatic = (imtd.getAccess() & ACC_STATIC) != 0;
+                    } else {
+                        isStatic = mmtd.getMetadata().containsKey("is_static");
+                    }
+                    
+                    if (!isStatic)
                         tmp.add("this");
-
                     Type[] args = Type.getArgumentTypes(mmtd.getDescriptor());
                     for (int x = 0; x < args.length; x++) {
                         String name = mmtd.remapParameter(x, null);


### PR DESCRIPTION
this can occur if the remapping classpath is incomplete

@TheCurle, this should resolve the issue you were having. Could you confirm?

Looking into this area more for this fix, there are a few more open questions about parameter remapping:

- How do we handle mappings formats that don't contain static information -- is the memory impact of explicitly adding a true/false static key to every method mapping worth it?
- I have had a request from a user to be able to provide parameter/LVT mappings from old name to new name, not by index as is common. What is a sensible way to do that? Probably both inheritance/bytecode models and mappings models would need slight changes, to track the original names from bytecode, but supporting both index-based and name-based is a touch awkward.