### PR TITLE
Add more descriptive information to rethrown exceptions

### DIFF
--- a/src/main/java/net/minecraftforge/fart/internal/FFLineFixer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/FFLineFixer.java
@@ -77,7 +77,7 @@ public final class FFLineFixer implements Transformer {
                 }
             }
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Could not create FFLineFixer for file: " + data.getAbsolutePath(), e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fart/internal/InheritanceImpl.java
+++ b/src/main/java/net/minecraftforge/fart/internal/InheritanceImpl.java
@@ -70,7 +70,7 @@ public class InheritanceImpl implements Inheritance {
                 sources.putIfAbsent(name, path);
             });
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Could not add library: " + path.getAbsolutePath(), e);
         }
     }
 
@@ -94,7 +94,7 @@ public class InheritanceImpl implements Inheritance {
                 byte[] data = Util.toByteArray(zf.getInputStream(entry));
                 return Optional.of(new ClassInfo(data));
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new RuntimeException("Could not get data to compute class info in: " + source.getAbsolutePath(), e);
             }
         } else {
             try {

--- a/src/main/java/net/minecraftforge/fart/internal/InheritanceImpl.java
+++ b/src/main/java/net/minecraftforge/fart/internal/InheritanceImpl.java
@@ -94,7 +94,7 @@ public class InheritanceImpl implements Inheritance {
                 byte[] data = Util.toByteArray(zf.getInputStream(entry));
                 return Optional.of(new ClassInfo(data));
             } catch (IOException e) {
-                throw new RuntimeException("Could not get data to compute class info in: " + source.getAbsolutePath(), e);
+                throw new RuntimeException("Could not get data to compute class info in file: " + source.getAbsolutePath(), e);
             }
         } else {
             try {

--- a/src/main/java/net/minecraftforge/fart/internal/RenamerBuilder.java
+++ b/src/main/java/net/minecraftforge/fart/internal/RenamerBuilder.java
@@ -65,7 +65,7 @@ public class RenamerBuilder implements Builder {
         try {
             add(Transformer.renamerFactory(IMappingFile.load(value)));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Could not map file: " + value.getAbsolutePath(), e);
         }
         return this;
     }

--- a/src/main/java/net/minecraftforge/fart/internal/RenamerImpl.java
+++ b/src/main/java/net/minecraftforge/fart/internal/RenamerImpl.java
@@ -164,7 +164,7 @@ class RenamerImpl implements Renamer {
                     zos.closeEntry();
                 }
             } catch (IOException e) {
-                throw new RuntimeException("Could write output to file: " + output.getAbsolutePath(), e);
+                throw new RuntimeException("Could not write output to file: " + output.getAbsolutePath(), e);
             }
         } finally {
             async.shutdown();

--- a/src/main/java/net/minecraftforge/fart/internal/RenamerImpl.java
+++ b/src/main/java/net/minecraftforge/fart/internal/RenamerImpl.java
@@ -164,7 +164,7 @@ class RenamerImpl implements Renamer {
                     zos.closeEntry();
                 }
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new RuntimeException("Could write output to file: " + output.getAbsolutePath(), e);
             }
         } finally {
             async.shutdown();


### PR DESCRIPTION
Some exceptions are mysterious because there isn't a good way to see what file is causing the problem.
This PR makes sure any rethrown errors add any extra information that's available, to help users of this library debug crashes.