### PR TITLE
Relocate shaded deps to be under FART's package

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -37,7 +37,7 @@ project {
         text("env.PUBLISHED_JAVA_ARTIFACT_ID", "ForgeAutoRenamingTool", label = "Published artifact id", description = "The maven coordinate artifact id that has been published by this build. Can not be empty.", allowEmpty = false)
         text("env.PUBLISHED_JAVA_GROUP", "net.minecraftforge", label = "Published group", description = "The maven coordinate group that has been published by this build. Can not be empty.", allowEmpty = false)
         text("docker_jdk_version", "8", label = "JDK version", description = "The version of the JDK to use during execution of tasks in a JDK.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
-        text("docker_gradle_version", "7.2", label = "Gradle version", description = "The version of Gradle to use during execution of Gradle tasks.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
+        text("docker_gradle_version", "7.4.1", label = "Gradle version", description = "The version of Gradle to use during execution of Gradle tasks.", display = ParameterDisplay.HIDDEN, allowEmpty = false)
     }
 
     features {

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ java.withSourcesJar()
 
 shadowJar {
     manifest.from(MANIFEST)
+    minimize()
 
     def relocations = [
             'org.objectweb.asm',

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,19 @@ java.withSourcesJar()
 
 shadowJar {
     manifest.from(MANIFEST)
+
+    def relocations = [
+            'org.objectweb.asm',
+            'net.minecraftforge.srgutils',
+            'joptsimple'
+    ]
+
+    relocations.forEach {
+        relocate it, "net.minecraftforge.fart.relocated.$it"
+    }
 }
+
+assemble.dependsOn shadowJar
 
 publishing {
     publications {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Relocation should limit conflicts with deps of different versions depending on the environment that FART's fat jar is run in. Also updated Gradle to 7.4.1.