### PR TITLE
Fix FF line number remapping

### DIFF
--- a/src/main/java/net/minecraftforge/fart/internal/FFLineFixer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/FFLineFixer.java
@@ -123,7 +123,7 @@ public final class FFLineFixer implements Transformer {
             return new MethodVisitor(RenamerImpl.MAX_ASM_VERSION, parent) {
                 @Override
                 public void visitLineNumber(final int line, final Label start) {
-                    Map.Entry<Integer, Integer> nline = lines.higherEntry(line);
+                    Map.Entry<Integer, Integer> nline = lines.ceilingEntry(line);
                     if (nline != null) {
                         madeChange = true;
                         super.visitLineNumber(nline.getValue(), start);


### PR DESCRIPTION
Currently, lines are found in the NavigableMap through `higherEntry`. This is documented as finding key-value entries that are exclusively greater than the current key. However, this is not proper because an exact line number match should produce the same entry. E.g. if line number 5 is found in the method visitor and the line map contains an entry of 5 -> 6, this entry should be selected and used, rather than a higher one. So, `ceilingEntry` is used instead, as this finds a key-value entry greater than or equal to the provided key, which fixes encountered bugs.