### PR TITLE
Rename constant pool entries in place

### DIFF
--- a/src/main/java/net/minecraftforge/fart/internal/RenamingTransformer.java
+++ b/src/main/java/net/minecraftforge/fart/internal/RenamingTransformer.java
@@ -48,7 +48,7 @@ public class RenamingTransformer implements Transformer {
     @Override
     public ClassEntry process(ClassEntry entry) {
         ClassReader reader = new ClassReader(entry.getData());
-        ClassWriter writer = new ClassWriter(reader, 0);
+        ClassWriter writer = new ClassWriter(0);
         ClassRemapper remapper = new EnhancedClassRemapper(writer, this.remapper, this);
 
         reader.accept(remapper, 0);


### PR DESCRIPTION
The current use of [`ClassWriter(ClassReader,int)`](https://asm.ow2.io/javadoc/org/objectweb/asm/ClassWriter.html#%3Cinit%3E(org.objectweb.asm.ClassReader,int)) meant that all existing constant pool entries from the `ClassReader` are copied as-is to the new class, and any renamed constant pool entries are merely appended to the pool rather than replacing the original non-renamed entries (as specified in the javadoc of said `ClassWriter` constructor).

To avoid the waste of constant pool space by those unused non-renamed entries, RenamingTransformer now creates a fresh `ClassWriter` (by not passing in the `ClassReader`).

> **Note**: ASM does some reordering of the constant pool (and some other attributes) that deviate from the order outputted by `javac`. This means a straight comparison of disassembly (using `javap`) of the outputs from `javac` and FART will show a "completely changed" constant pool, due to the reordering.

This change brings the output of FART in line with SpecialSource. Aside from a difference explainable by the ZIP timestamp preferences of each tool, disassembly shows no differences between the output of SpecialSource and FART (with this modification applied).